### PR TITLE
Fix scratchpad logging argument handling

### DIFF
--- a/TextEnhanceAI.py
+++ b/TextEnhanceAI.py
@@ -388,12 +388,14 @@ class EditorApp:
     # --------------
     # Logging / Scratchpad
     # --------------
-    def log_to_scratchpad(self, text):
+    def log_to_scratchpad(self, *texts):
         """Write changes and actions to the scratchpad file."""
         if not self.scratchpad_filename:
             return
         with open(self.scratchpad_filename, "a", encoding="utf-8") as f:
-            f.write(text + "\n")
+            for text in texts:
+                f.write(text)
+            f.write("\n")
 
 
 # --------------


### PR DESCRIPTION
## Summary
- handle multiple texts in `log_to_scratchpad`
- use new signature when logging AI generated diff output

## Testing
- `python -m py_compile TextEnhanceAI.py`

------
https://chatgpt.com/codex/tasks/task_e_6841e0bac9bc8320a4c5bf7aa1bd63b2